### PR TITLE
efihex error checking

### DIFF
--- a/efi/efihex/conv.go
+++ b/efi/efihex/conv.go
@@ -17,6 +17,10 @@ package efihex
 const hexTable = "0123456789ABCDEF"
 
 func EncodeBigEndian(dst, src []byte) {
+	if len(src) <= 0 {
+		return
+	}
+
 	_ = dst[len(src)*2-1] // bounds check hint to compiler
 	for i, j := 0, 0; i < len(src); i, j = i+1, j+2 {
 		dst[j], dst[j+1] = hexTable[src[i]>>4], hexTable[src[i]&0x0f]


### PR DESCRIPTION
Hello,

In some instances when using efibootctl, I get index out of bounds exception, essentially with dst[-1] because len(src) is 0. I am not sure exactly what the input bytes were, but this change fixed it for me.

Hristo