### PR TITLE
Adding marshaller to BootOrder

### DIFF
--- a/efi/efivars/bootvariables.go
+++ b/efi/efivars/bootvariables.go
@@ -74,6 +74,7 @@ var (
 		guid:         GlobalVariable,
 		defaultAttrs: defaultAttrs,
 		unmarshal:    sliceUnmarshaller[uint16],
+		marshal:      sliceMarshaller[uint16],
 	}
 )
 


### PR DESCRIPTION
Looks like there was a missing marshaller for the BootOrder variable (unless there was a good reason why this was left out). I tried it on a qemu machine and the `Set()` worked as expected with this change.